### PR TITLE
Service print

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Variables
 APACHE_ENTRY_PATH := $(shell if [ '$(APACHE_BASE_PATH)' = 'main' ]; then echo ''; else echo /$(APACHE_BASE_PATH); fi)
 APP_VERSION := $(shell python -c "print __import__('time').strftime('%s')")
-BASEWAR := print-servlet-3.3-SNAPSHOT.war
+BASEWAR ?= print-servlet-3.3-SNAPSHOT.war
 BRANCH_STAGING := $(shell if [ '$(DEPLOY_TARGET)' = 'dev' ]; then echo 'test'; else echo 'integration'; fi)
 BRANCH_TO_DELETE :=
 CURRENT_DIRECTORY := $(shell pwd)
@@ -18,7 +18,7 @@ PRINT_INPUT :=  index.html favicon.ico print-apps mapfish_transparent.png META-I
 PRINT_OUTPUT_BASE := /srv/tomcat/tomcat1/webapps/service-print-$(APACHE_BASE_PATH)
 PRINT_OUTPUT := $(PRINT_OUTPUT_BASE).war
 PRINT_TEMP_DIR := /var/cache/print
-PYTHON_FILES := $(shell find print/* -path print/static -prune -o -type f -name "*.py" -print)
+PYTHON_FILES := $(shell find print3/* -path print/static -prune -o -type f -name "*.py" -print)
 SHORTENER_ALLOWED_DOMAINS := admin.ch, swisstopo.ch, bgdi.ch
 SHORTENER_ALLOWED_HOSTS :=
 TEMPLATE_FILES := $(shell find -type f -name "*.in" -print)
@@ -330,6 +330,12 @@ fixrights:
 	@echo "${GREEN}Fixing rights...${RESET}";
 	chgrp -f -R geodata . || :
 	chmod -f -R g+srwX . || :
+
+.PHONY: cleancache
+cleancache:
+	rm -rf /var/cache/print/*.pdf
+	rm -rf /var/cache/print/*.json
+	rm -rf /var/cache/print/mapfish*
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,16 @@ HTTP_PROXY := http://ec2-52-28-118-239.eu-central-1.compute.amazonaws.com:80
 INSTALL_DIRECTORY := .venv
 MODWSGI_USER := www-data
 NO_TESTS ?= withtests
-NODE_DIRECTORY := node_modules
-PRINT_URL ?= //service-print.dev.bgdi.ch
+PRINT_PROXY_URL ?= //service-print.dev.bgdi.ch
+PRINT_SERVER_URL ?= ${PRINT_PROXY_URL}/printserver
 PRINT_INPUT :=  index.html favicon.ico print-apps mapfish_transparent.png META-INF WEB-INF
 PRINT_OUTPUT_BASE := /srv/tomcat/tomcat1/webapps/service-print-$(APACHE_BASE_PATH)
 PRINT_OUTPUT := $(PRINT_OUTPUT_BASE).war
 PRINT_TEMP_DIR := /var/cache/print
 PYTHON_FILES := $(shell find print3/* -path print/static -prune -o -type f -name "*.py" -print)
-SHORTENER_ALLOWED_DOMAINS := admin.ch, swisstopo.ch, bgdi.ch
-SHORTENER_ALLOWED_HOSTS :=
 TEMPLATE_FILES := $(shell find -type f -name "*.in" -print)
 USERNAME := $(shell whoami)
 WSGI_APP := $(CURRENT_DIRECTORY)/apache/application.wsgi
-ZADARA_DIR := /var/local/cartoweb/downloads/
 
 # Commands
 AUTOPEP8_CMD := $(INSTALL_DIRECTORY)/bin/autopep8
@@ -34,7 +31,6 @@ NOSE_CMD := $(INSTALL_DIRECTORY)/bin/nosetests
 PIP_CMD := $(INSTALL_DIRECTORY)/bin/pip
 PSERVE_CMD := $(INSTALL_DIRECTORY)/bin/pserve
 PYTHON_CMD := $(INSTALL_DIRECTORY)/bin/python
-SPHINX_CMD := $(INSTALL_DIRECTORY)/bin/sphinx-build
 
 # Linting rules
 PEP8_IGNORE := "E128,E221,E241,E251,E272,E501,E711,E731"
@@ -56,7 +52,6 @@ GREEN := $(shell tput setaf 2)
 # Versions
 # We need GDAL which is hard to install in a venv, modify PYTHONPATH to use the
 # system wide version.
-GDAL_VERSION ?= 1.9.0
 PYTHON_VERSION := $(shell python --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
 PYTHONPATH ?= .venv/lib/python${PYTHON_VERSION}/site-packages:/usr/lib64/python${PYTHON_VERSION}/site-packages
 SERVER_ID := $(shell ${PYTHON_CMD}  -c 'import uuid; print uuid.uuid1()')
@@ -73,13 +68,9 @@ help:
 	@echo "- teste2e            Launch end-to-end tests"
 	@echo "- lint               Run the linter"
 	@echo "- autolint           Run the autolinter"
-	@echo "- translate          Generate the translation files"
-	@echo "- doc                Generate the doc for api3.geo.admin.ch"
 	@echo "- deploybranch       Deploy current branch to dev (must be pushed before hand)"
 	@echo "- deploybranchint    Deploy current branch to dev and int (must be pushed before hand)"
-	@echo "- deploybranchdemo   Deploy current branch to dev and demo (must be pushed before hand)"
 	@echo "- deletebranch       List deployed branches or delete a deployed branch (BRANCH_TO_DELETE=...)"
-	@echo "- updateapi          Updates geoadmin api source code (ol3 fork)"
 	@echo "- printconfig        Set tomcat print env variables"
 	@echo "- printwar           Creates the .jar print file (only one per env per default)"
 	@echo "- deploydev          Deploys master to dev (SNAPSHOT=true to also create a snapshot)"
@@ -91,11 +82,9 @@ help:
 	@echo "Variables:"
 	@echo "APACHE_ENTRY_PATH:   ${APACHE_ENTRY_PATH}"
 	@echo "API_URL:             ${API_URL}"
-	@echo "PRINT_URL:           ${PRINT_URL}"
+	@echo "PRINT_PROXY_URL:     ${PRINT_PROXY_URL}"
+	@echo "PRINT_SERVER_URL:    ${PRINT_SERVER_URL}"
 	@echo "BRANCH_STAGING:      ${BRANCH_STAGING}"
-	@echo "DBHOST:              ${DBHOST}"
-	@echo "DBSTAGING:           ${DBSTAGING}"
-	@echo "GEOADMINHOST:        ${GEOADMINHOST}"
 	@echo "GIT_BRANCH:          ${GIT_BRANCH}"
 	@echo "SERVER_PORT:         ${SERVER_PORT}"
 	@echo
@@ -206,9 +195,6 @@ deployint:
 deployprod:
 	scripts/deploysnapshot.sh $(SNAPSHOT) prod $(NO_TESTS) $(DEPLOYCONFIG)
 
-.PHONY: deploydemo
-deploydemo:
-	scritps/deploysnapshot.sh $(SNAPSHOT) demo
 
 rc_branch.mako:
 	@echo "${GREEN}Branch has changed${RESET}";
@@ -272,7 +258,6 @@ apache/wsgi.conf: apache/wsgi.conf.in apache/application.wsgi
 		--var "modwsgi_user=$(MODWSGI_USER)" \
 		--var "wsgi_threads=$(WSGI_THREADS)" \
 		--var "wsgi_app=$(WSGI_APP)" \
-		--var "zadara_dir=$(ZADARA_DIR)" \
 		--var "print_temp_dir=$(PRINT_TEMP_DIR)" $< > $@
 
 development.ini.in:
@@ -294,24 +279,12 @@ production.ini: production.ini.in
 		--var "apache_entry_path=$(APACHE_ENTRY_PATH)" \
 		--var "apache_base_path=$(APACHE_BASE_PATH)" \
 		--var "current_directory=$(CURRENT_DIRECTORY)" \
-		--var "dbhost=$(DBHOST)" \
-		--var "dbport=$(DBPORT)" \
-		--var "dbstaging=$(DBSTAGING)" \
-		--var "zadara_dir=$(ZADARA_DIR)" \
 		--var "api_url=$(API_URL)" \
-		--var "print_url=$(PRINT_URL)" \
-		--var "geodata_staging=$(GEODATA_STAGING)" \
-		--var "sphinxhost=$(SPHINXHOST)" \
-		--var "wmshost=$(WMSHOST)" \
-		--var "webdav_host=$(WEBDAV_HOST)" \
-		--var "mapproxyhost=$(MAPPROXYHOST)" \
-		--var "geoadminhost=$(GEOADMINHOST)" \
+		--var "print_proxy_url=$(PRINT_PROXY_URL)" \
+		--var "print_server_url=$(PRINT_SERVER_URL)" \
 		--var "host=$(HOST)" \
 		--var "print_temp_dir=$(PRINT_TEMP_DIR)" \
-		--var "http_proxy=$(HTTP_PROXY)" \
-		--var "geoadmin_file_storage_bucket=$(GEOADMIN_FILE_STORAGE_BUCKET)" \
-		--var "shortener_allowed_hosts=$(SHORTENER_ALLOWED_HOSTS)" \
-		--var "shortener_allowed_domains=$(SHORTENER_ALLOWED_DOMAINS)" $< > $@
+		--var "http_proxy=$(HTTP_PROXY)"  $< > $@
 
 requirements.txt:
 	@echo "${GREEN}File requirements.txt has changed${RESET}";

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Print service for [https://map.geo.admin.ch], based on [MapFish Print v3](http:/
 
 Checkout the source code:
 
-    git clone https://github.com/geoadmin/mf-chsdi3.git
+    git clone https://github.com/geoadmin/print-service.git
 
 or when you're using ssh key (see https://help.github.com/articles/generating-ssh-keys):
 
-    git clone git@github.com:geoadmin/mf-chsdi3.git
+    git clone git@github.com:geoadmin/print-service.git
 
 
 Create a developer specific build configuration:
@@ -28,11 +28,11 @@ Where "username" is your specific rc configuration. To create the specific build
 
 If you do this on mf1t, you need to make sure that a correct configuration exists under
     
-    /var/www/vhosts/mf-chsdi3/conf
+    /var/www/vhosts/print-service/conf
 
 that points to your working directory. If all is well, you can reach your pages at:
 
-    http://mf-chsdi3.dev.bgdi.ch/<username>/
+    http://print-service.dev.bgdi.ch/<username>/
 
 ## Python Code Styling
 

--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -3,12 +3,47 @@
     Allow from all
 </Proxy>
 
+
+
+# V3
+# 
+# GET  /print/print/geoadmin3/capabilities.json
+#
+# POST /print/print/geoadmin3/report.json
+#
+# GET  /print/print/status/fcacc8d5-3970-4477-b98a-718fd6abcadd@505d796f-3ffc-4e55-889e-226e189dba37.json 
+# 
+# GET  /print/service-print-main/print/report/08e117fd-fd16-4074-8bea-b1329fb98b6b@050480a2-0a05-44e4-8a90-8a68d8d24545
+
+
+# V2
+#
+# GET  /print/info.json
+#
+# POST /print/create.json
+#
+# POST /multiprint/create.json
+#
+# GET  /printprogress?id=232323
+#
+# GET  /printcancel
+#
+# GET /print/-multi23444545.pdf.printout
+
+# V3
+RewriteRule  ${apache_entry_path}/print/service-print-${apache_base_path}/print/report/(.*)   ${apache_entry_path}/print/print/report/$1 [PT]
+
+
 # JSON print requests to print server
 ProxyPassMatch ${apache_entry_path}/print/(.*) ajp://localhost:8009/service-print-${print_war}/$1
 ProxyPassReverse ${apache_entry_path}/print/ ajp://localhost:8009/service-print-${print_war}/
 
 # Get resulting files directly from filesystem
 AliasMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ ${print_temp_dir}/mapfish-print$2$3
+
+
+
+
 
 <LocationMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ >
   Header set Content-Disposition "attachment; filename=map.geo.admin.ch.pdf"

--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -31,21 +31,36 @@
 # GET /print/-multi23444545.pdf.printout
 
 # V3
-RewriteRule  ${apache_entry_path}/print/service-print-${apache_base_path}/print/report/(.*)   ${apache_entry_path}/print/print/report/$1 [PT]
-
-
-# JSON print requests to print server
-ProxyPassMatch ${apache_entry_path}/print/(.*) ajp://localhost:8009/service-print-${print_war}/$1
-ProxyPassReverse ${apache_entry_path}/print/ ajp://localhost:8009/service-print-${print_war}/
-
-# Get resulting files directly from filesystem
-AliasMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ ${print_temp_dir}/mapfish-print$2$3
+#RewriteRule  ${apache_entry_path}/print/service-print-${apache_base_path}/print/report/(.*)   ${apache_entry_path}/print/print/report/$1 [PT]
 
 
 
+# Three base path are defined
+# - /printserver     Tomcat application
+# - /print           Print proxy (pyramid WSGI)
+# - /download        Aapche direct download
 
 
-<LocationMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ >
+# capabilities document direct to tomcat
+RewriteRule  ^${apache_entry_path}/print/print/(\w+)/capabilities.json    /printserver/print/$1/capabilities.json [PT]
+
+# Print server
+ProxyPassMatch   ${apache_entry_path}/printserver/(.*) ajp://localhost:8009/service-print-${print_war}/$1
+ProxyPassReverse ${apache_entry_path}/printserver/ ajp://localhost:8009/service-print-${print_war}/
+
+
+# Print proxy
+RewriteRule  ^${apache_entry_path}/print/print/(.*)     /print/$1 [PT]
+
+
+
+# Download 
+AliasMatch ^${apache_entry_path}/download/(.+) ${print_temp_dir}/mapfish-print$1
+
+
+
+
+<LocationMatch ^${apache_entry_path}/download/(\-multi)?([0-9a-f@-_]+\.pdf\.printout)$ >
   Header set Content-Disposition "attachment; filename=map.geo.admin.ch.pdf"
   # Try to force IE to open the PDF in a new window
   # overriding what set by the print server

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -12,25 +12,21 @@ active = false
 
 [code]
 #ignore = *.pyc, .svn
-dir = /var/www/vhosts/service-print/private/chsdi/
+dir = /var/www/vhosts/service-print/private/print/
 
 [apache]
 dest = /var/www/vhosts/service-print/conf/99-print.conf
 content = Include /var/www/vhosts/service-print/private/print/apache/*.conf
 
 [remote_hosts]
-# mf0i
-int = ip-10-220-6-119.eu-west-1.compute.internal,
-      ip-10-220-6-41.eu-west-1.compute.internal,
-      ip-10-220-6-105.eu-west-1.compute.internal,
-      ip-10-220-6-208.eu-west-1.compute.internal
+# Only legacy-int
+int = ip-10-220-6-41.eu-west-1.compute.internal,
+      ip-10-220-6-105.eu-west-1.compute.internal
 
 
-# mf0 --> vpc_mf0_legacy_prod and vpc_mf0_prod
+# Only legacy-prod
 prod = ip-10-220-5-86.eu-west-1.compute.internal,
-       ip-10-220-6-138.eu-west-1.compute.internal,
-       ip-10-220-5-201.eu-west-1.compute.internal,
-       ip-10-220-6-126.eu-west-1.compute.internal
+       ip-10-220-6-138.eu-west-1.compute.internal
 
 # bakom demo instance dec 2014
 demo = ip-10-220-5-174.eu-west-1.compute.internal

--- a/print3/__init__.py
+++ b/print3/__init__.py
@@ -23,14 +23,17 @@ def main(global_config, **settings):
 
     # route definitions
     config.add_route('ogcproxy', '/ogcproxy')
-    config.add_route('print_create', '/printmulti/create.json')
-    config.add_route('print_progress', '/printprogress')
-    config.add_route('print_cancel', '/printcancel')
+    config.add_route('print_create', '/print/geoadmin3/report.pdf')
+    config.add_route('print_progress', '/print/status/{id}.json')
+    config.add_route('print_cancel', '/print/cancel/{id}')
+    #config.add_route('print_progress', '/printprogress')
+    #config.add_route('print_cancel', '/printcancel')
     config.add_route('dev', '/dev')
     config.add_route('checker', '/checker')
     config.add_route('checker_dev', '/checker_dev')
 
 
+    config.add_route('get_timestamps', '/printmulti/timestamps')
     # required to find code decorated by view_config
     config.scan(ignore=['print3.tests', 'print3.models.bod'])
     return config.make_wsgi_app()

--- a/print3/__init__.py
+++ b/print3/__init__.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pyramid.config import Configurator
-from pyramid.events import BeforeRender, NewRequest
 from pyramid.renderers import JSONP
-
-
-
 
 
 def main(global_config, **settings):
@@ -15,25 +11,21 @@ def main(global_config, **settings):
     settings['app_version'] = app_version
     config = Configurator(settings=settings)
 
-
     # renderers
-    #config.add_mako_renderer('.js')
     config.add_renderer('jsonp', JSONP(param_name='callback', indent=None, separators=(',', ':')))
-
 
     # route definitions
     config.add_route('ogcproxy', '/ogcproxy')
     config.add_route('print_create', '/print/geoadmin3/report.pdf')
     config.add_route('print_progress', '/print/status/{id}.json')
     config.add_route('print_cancel', '/print/cancel/{id}')
-    #config.add_route('print_progress', '/printprogress')
-    #config.add_route('print_cancel', '/printcancel')
     config.add_route('dev', '/dev')
     config.add_route('checker', '/checker')
     config.add_route('checker_dev', '/checker_dev')
 
-
     config.add_route('get_timestamps', '/printmulti/timestamps')
+    config.add_static_view('/', 'print3:static/')
+
     # required to find code decorated by view_config
     config.scan(ignore=['print3.tests', 'print3.models.bod'])
     return config.make_wsgi_app()

--- a/print3/static/index.html
+++ b/print3/static/index.html
@@ -1,0 +1,9 @@
+<h1>service-print</h1>
+
+<ul>
+    <li><a href="printserver/">printserver (tomcat)</li>
+    <li><a href="download"/>download (protected)</li>
+    <li><a href="print">print (print proxy, protected)</li>
+    <li><a href="print/print/geoadmin3/capabilities.json">print capabilities.json</li>
+    <li><a href="print/print/status/1603291612192627.json">print status</li>
+</ul>

--- a/print3/views/printmulti.py
+++ b/print3/views/printmulti.py
@@ -5,6 +5,7 @@ import os.path
 import traceback
 import sys
 import urllib
+import urllib2
 import json
 import re
 import copy
@@ -12,6 +13,7 @@ import datetime
 import time
 import multiprocessing
 import random
+import uuid
 from urlparse import urlparse, parse_qs, urlsplit, urlunparse
 from urllib import urlencode, quote_plus, unquote_plus
 
@@ -28,11 +30,16 @@ from print3.lib.decorators import requires_authorization
 import logging
 log = logging.getLogger(__name__)
 
+log.setLevel(logging.DEBUG)
+
 
 NUMBER_POOL_PROCESSES = multiprocessing.cpu_count()
 MAPFISH_FILE_PREFIX = 'mapfish-print'
 MAPFISH_MULTI_FILE_PREFIX = MAPFISH_FILE_PREFIX + '-multi'
-USE_MULTIPROCESS = True
+USE_MULTIPROCESS = False
+
+
+currentFuncName = lambda n=0: sys._getframe(n + 1).f_code.co_name
 
 
 def _zeitreihen(d, api_url):
@@ -61,7 +68,7 @@ def _increment_info(l, filename):
         with open(filename, 'r') as infile:
             data = json.load(infile)
 
-        data['done'] = data['done'] + 1
+        data['printed'] = data['printed'] + 1
 
         with open(filename, 'w+') as outfile:
             json.dump(data, outfile)
@@ -82,13 +89,30 @@ def _normalize_imageDisplay(display):
         str(int(display[1] * ratio)) + ',' + \
         str(targetDPI)
 
-
+def _get_layers(spec):
+    try:
+        layers = spec['attributes']['map']['layers']
+    except KeyError:
+        layers = []
+        
+    return layers
+        
+    
+@view_config(route_name='get_timestamps', renderer='jsonp')
+def get_timestamps(self):
+        jsonstring = urllib.unquote_plus(self.body)
+        spec = json.loads(jsonstring, encoding=self.charset)
+        
+        api_url = "//api3.geo.admin.ch"
+        
+        return _get_timestamps(spec, api_url)
+        
 def _get_timestamps(spec, api_url):
     '''Returns the layers indices to be printed for each timestamp
     For instance (u'19971231', [1, 2]), (u'19981231', [0, 1, 2])  '''
 
     results = {}
-    lyrs = spec.get('layers', [])
+    lyrs = _get_layers(spec)
     log.debug('[_get_timestamps] layers: %s', lyrs)
     for idx, lyr in enumerate(lyrs):
         # For zeitreihen, we always get the timestamps from the service
@@ -114,7 +138,16 @@ def _get_timestamps(spec, api_url):
                 log.debug(str(e))
                 timestamps = lyr['timestamps'] if 'timestamps' in lyr.keys() else None
         else:
-            timestamps = lyr['timestamps'] if 'timestamps' in lyr.keys() else None
+            dimensions = lyr.get('dimensions')
+            if dimensions is not None and 'Time' in dimensions:
+                params = lyr.get('dimensionParams')
+                if params is not None:
+                    try:
+                        timestamp = params.get('TIME')
+                        timestamps = [int(timestamp) if timestamp != 'current' else timestamp]
+                    except:
+                        timestamps = None
+                  
 
         if timestamps is not None:
             for ts in timestamps:
@@ -195,43 +228,77 @@ def worker(job):
 
     timestamp = None
     (idx, url, headers, timestamp, layers, tmp_spec, print_temp_dir, infofile, cancelfile, lock) = job
-
-    for layer in layers:
+    
+    
+    
+    for lyr in tmp_spec['attributes']['map']['layers']:
         try:
-            tmp_spec['layers'][layer]['params']['TIME'] = str(timestamp)
+            del lyr['timestamps']  # this makes print server crash
+            layername = lyr['layer']
+            if layername in layers:
+            
+                lyr['dimensionParams']['TIME'] = str(timestamp)
         except:
-            continue
+            log.debug('[worker] Cannot fixe tmp_spec')
+            
+    log.debug('[worker] Finale partial spec\n----------------\n%s\n---------------\n', json.dumps(tmp_spec, indent=4, sort_keys=True))
+    #with open(os.path.join(print_temp_dir, '{}.json'.format(idx)), 'w+') as f:
+    #              f.write( json.dumps(tmp_spec, indent=4, sort_keys=True))
 
-    log.debug('spec: %s', json.dumps(tmp_spec))
+    #log.debug('[worker] tmp_spec: %s', json.dumps(tmp_spec))
 
     # Before launching print request, check if process is canceled
     if os.path.isfile(cancelfile):
         return (timestamp, None)
+    log.debug('[Worker] Requesting partial PDF for: %s', timestamp)
+    #h = {'Referer': headers.get('Referer', 'http://map.geo.admin.ch'),#FIXME has to be somehting
+    #     'Content-Type': 'application/json'} 
+    #log.debug('[worker] headers: %s', h)
+    #http = Http(disable_ssl_certificate_validation=True)
+    #resp, content = http.request(url, method='POST',
+    #                            body=json.dumps(tmp_spec), headers=h)
 
-    h = {'Referer': headers.get('Referer')}
-    http = Http(disable_ssl_certificate_validation=True)
-    resp, content = http.request(url, method='POST',
-                                 body=json.dumps(tmp_spec), headers=h)
-
-    if int(resp.status) == 200:
-        # GetURL '141028163227.pdf.printout', file 'mapfish-print141028163227.pdf.printout'
-        # We only get the pdf name and rely on the fact that they are stored on Zadara
-        try:
-            pdf_url = json.loads(content)['getURL']
-            log.debug('[Worker] pdf_url: %s', pdf_url)
-            filename = os.path.basename(urlsplit(pdf_url).path)
+    #if int(resp.status) == 200:
+    #    # GetURL '141028163227.pdf.printout', file 'mapfish-print141028163227.pdf.printout'
+    #    # We only get the pdf name and rely on the fact that they are stored on Zadara
+    #    log.debug('[Worker] headers: {}'.format(dir(resp)))
+    referer =  headers.get('Referer', '-')
+    opener = urllib2.build_opener(urllib2.HTTPHandler())
+    request = urllib2.Request(url, data=json.dumps(tmp_spec))
+    request.add_header("Content-Type",'application/json')
+    request.add_header("Referer", referer)
+        
+        
+      
+    try:
+            #pdf_url = json.loads(content)['downloadURL']
+            #log.debug('[Worker] pdf_url: {}'.format(pdf_url))
+            #filename = os.path.basename(urlsplit(pdf_url).path)
+            filename = str(uuid.uuid1())
             localname = os.path.join(print_temp_dir, MAPFISH_FILE_PREFIX + filename)
-        except:
+     
+            connection = opener.open(request)
+    except:
             log.debug('[Worker] Failed timestamp: %s', timestamp)
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            log.debug("*** Traceback:/n" + traceback.print_tb(exc_traceback, limit=1, file=sys.stdout))
-            log.debug("*** Exception:/n" + traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout))
-
+            log.debug("*** Traceback:/n{}".format(traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)))
+            log.debug("*** Exception:/n{}".format(traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)))
+            
             return (timestamp, None)
+      
+    if connection.code == 200:
+        CHUNK = 1024 * 50
+        with open(localname, 'wb') as fp:
+            while True:
+                    chunk = connection.read(CHUNK)
+                    if not chunk: break
+                    fp.write(chunk)
         _increment_info(lock, infofile)
+        log.debug('[Worker] Partial PDF written to: %s', localname)
+        
         return (timestamp, localname)
     else:
-        log.debug('[Worker] Failed get/generate PDF for: %s. Error: %s', timestamp, resp.status)
+        log.debug('[Worker] Failed get/generate PDF for: %s. Error: %s', timestamp, connection.code)
         log.debug('[Worker] %s', content)
         return (timestamp, None)
 
@@ -241,7 +308,7 @@ def worker(job):
 def create_and_merge(info):
 
     lock = multiprocessing.Manager().Lock()
-    (spec, print_temp_dir, scheme, api_url, headers, unique_filename) = info
+    (spec, print_temp_dir, scheme, api_url, print_url, headers, unique_filename) = info
 
     def _isMultiPage(spec):
         isMultiPage = False
@@ -257,7 +324,7 @@ def create_and_merge(info):
             info_json = json.load(data_file)
 
         info_json['merged'] = 0
-
+        
         def write_info():
             with open(infofile, 'w+') as outfile:
                 json.dump(info_json, outfile)
@@ -281,12 +348,15 @@ def create_and_merge(info):
         try:
             info_json['filesize'] = expected_file_size
             info_json['written'] = 0
+            info_json['done'] = True
+            info_json['status'] = 'finished'
             write_info()
             filename = create_pdf_path(print_temp_dir, unique_filename)
             log.info('[_merge_pdfs] Writing file.')
             out = open(filename, 'wb')
             merger.write(out)
             log.info('[_merge_pdfs] Merged PDF written to: %s', filename)
+            log.debug(json.dumps(info_json, indent=4))
         except:
             return False
 
@@ -298,20 +368,28 @@ def create_and_merge(info):
 
     jobs = []
     all_timestamps = []
+    
+    
 
-    create_pdf_url = 'http:' + api_url + '/print/create.json'
+    ## FIXME Make it more flexible    
+    create_pdf_url = 'http:' + print_url + '/printserver/print/geoadmin3/buildreport.pdf'
 
     url = create_pdf_url + '?url=' + urllib.quote_plus(create_pdf_url)
     infofile = create_info_file(print_temp_dir, unique_filename)
     cancelfile = create_cancel_file(print_temp_dir, unique_filename)
+    
+    pdf_download_path = '/download/-multi' + unique_filename + '.pdf.printout'
 
     if _isMultiPage(spec):
         all_timestamps = _get_timestamps(spec, api_url)
         log.debug('[print_create] Going multipages')
         log.debug('[print_create] Timestamps to process: %s', all_timestamps.keys())
 
+    # FIXME jobs for single or multi should be the same
     if len(all_timestamps) < 1:
-        job = (0, url, headers, None, [], spec, print_temp_dir)
+        #job = (0, url, headers, None, [], spec, print_temp_dir)
+        job =  (0,   url, headers, None, [], spec, print_temp_dir, infofile, cancelfile, lock)
+        #job = (idx, url, headers, ts,   lyrs, tmp_spec, print_temp_dir, infofile, cancelfile, lock)
         jobs.append(job)
     else:
         last_timestamp = all_timestamps.keys()[-1]
@@ -320,15 +398,19 @@ def create_and_merge(info):
             lyrs = all_timestamps[ts]
 
             tmp_spec = copy.deepcopy(spec)
+            
+            # FIXMe no effect at all
+            # these are indexes
             for lyr in lyrs:
                 try:
-                    tmp_spec['layers'][lyr]['params']['TIME'] = str(ts)
+                    tmp_spec['attributes']['map']['layers'][lyr]['dimensionParams']['TIME'] = str(ts)
                 except KeyError:
                     pass
-
+            
             if ts is not None:
-                qrcodeurl = spec['qrcodeurl']
-                tmp_spec['pages'][0]['timestamp'] = str(ts[0:4]) + "\n"
+                # FIXME url qrcode
+                qrcodeurl = spec['attributes'].get('qrcodeurl', 'https://map.geo.admin.ch/') #['qrimage']
+                tmp_spec['pages'][0]['timestamp'] = str(ts[0:4]) # FIXME why did we add this char ???? + "\n"
 
                 ''' Adapteds the qrcode url and shortlink to match the timestamp
                     on every page of the PDF document'''
@@ -352,18 +434,31 @@ def create_and_merge(info):
             if 'legends' in tmp_spec.keys() and ts != last_timestamp:
                 del tmp_spec['legends']
                 tmp_spec['enableLegends'] = False
+                
+                
 
             log.debug('[print_create] Processing timestamp: %s', ts)
+            
+            
 
             job = (idx, url, headers, ts, lyrs, tmp_spec, print_temp_dir, infofile, cancelfile, lock)
 
             jobs.append(job)
 
     with open(infofile, 'w+') as outfile:
-        json.dump({'status': 'ongoing', 'done': 0, 'total': len(jobs)}, outfile)
+        data = {
+                "done": False,
+                "status": "running",
+                "elapsedTime":  len(jobs),
+                "waitingTime": 0,
+                "downloadURL": pdf_download_path 
+            }
+        
+        json.dump(data, outfile)
 
     if USE_MULTIPROCESS:
         pool = multiprocessing.Pool(NUMBER_POOL_PROCESSES)
+        log.debug('[{}] Using multiprocess for jobs: {}'.format(currentFuncName(), len(jobs)))
         pdfs = pool.map(worker, jobs)
         pool.close()
         try:
@@ -377,11 +472,12 @@ def create_and_merge(info):
                 del pool._pool[i]
             log.error('Error while generating the partial PDF: %s', e)
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            log.debug("*** Traceback:/n" + traceback.print_tb(exc_traceback, limit=1, file=sys.stdout))
-            log.debug("*** Exception:/n" + traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout))
+            log.debug("*** Traceback:/n{}".format(traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)))
+            log.debug("*** Exception:/n{}".format(traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)))
             return 1
     else:
         pdfs = []
+        log.debug('[{}] Using single process for jobs: {}'.format(currentFuncName(), len(jobs)))
         for j in jobs:
             pdfs.append(worker(j))
             _increment_info(lock, infofile)
@@ -400,11 +496,19 @@ def create_and_merge(info):
         log.error('Something went wrong while merging PDFs')
         return 3
 
-    pdf_download_url = scheme + ':' + api_url + '/print/-multi' + unique_filename + '.pdf.printout'
+    # FIXME
+    #pdf_download_url = scheme + ':' + api_url + '/print/-multi' + unique_filename + '.pdf.printout'
+    #pdf_download_path = '/download/-multi' + unique_filename + '.pdf.printout'
     with open(infofile, 'w+') as outfile:
-        json.dump({'status': 'done', 'getURL': pdf_download_url}, outfile)
+        #log.debug(infofile)
+        #data = json.load(outfile)
+        #data['done'] = True
+        #data['status'] = 'finished'
+        
+        #json.dump({'status': 'done', 'getURL': pdf_download_url}, outfile)
+        json.dump({'status':'finished', 'done':True,'downloadURL': pdf_download_path }, outfile)
 
-    log.info('[create_pdf] PDF ready to download: %s', pdf_download_url)
+    log.info('[create_pdf] PDF ready to download: %s', pdf_download_path)
 
     return 0
 
@@ -435,12 +539,15 @@ class PrintMulti(object):
 
     def __init__(self, request):
         self.request = request
+        self.server_id  = request.registry.settings['server_id']
 
     #@requires_authorization()
     @view_config(route_name='print_cancel', renderer='jsonp')
     def print_cancel(self):
+        if self.request.method == 'OPTIONS':
+            return Response(status=200)
         print_temp_dir = self.request.registry.settings['print_temp_dir']
-        fileid = self.request.params.get('id')
+        fileid = self.request.matchdict["id"]
         cancelfile = create_cancel_file(print_temp_dir, fileid)
         with open(cancelfile, 'a+'):
             pass
@@ -454,19 +561,22 @@ class PrintMulti(object):
     @view_config(route_name='print_progress', renderer='jsonp')
     def print_progress(self):
         print_temp_dir = self.request.registry.settings['print_temp_dir']
-        fileid = self.request.params.get('id')
+        fileid = self.request.matchdict["id"]
         filename = create_info_file(print_temp_dir, fileid)
         pdffile = create_pdf_path(print_temp_dir, fileid)
-
+        
         if not os.path.isfile(filename):
-            raise HTTPBadRequest()
+            raise HTTPBadRequest('No print job with id {}'.format(fileid))
 
         with open(filename, 'r') as data_file:
-            data = json.load(data_file)
+            try:
+                data = json.load(data_file)
+            except ValueError:
+                data = {'done': False, 'status':'error'}
 
         # When file is written, get current size
         if os.path.isfile(pdffile):
-            data['written'] = os.path.getsize(pdffile)
+            data['elapsedTime'] = os.path.getsize(pdffile)
 
         return data
 
@@ -488,28 +598,52 @@ class PrintMulti(object):
         except:
             log.debug('JSON content could not be parsed')
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            log.debug("*** Traceback:/n" + traceback.print_tb(exc_traceback, limit=1, file=sys.stdout))
-            log.debug("*** Exception:/n" + traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout))
-            raise HTTPBadRequest('JSON content could not be parsed')
+            log.debug("*** Traceback:/n{}".format(traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)))
+            log.debug("*** Exception:/n{}".format(traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)))
+            raise HTTPBadRequest('JSON is empty or content could not be parsed')
 
         print_temp_dir = self.request.registry.settings['print_temp_dir']
+        
 
         # Remove older files on the system
         delete_old_files(print_temp_dir)
 
         scheme = self.request.headers.get('X-Forwarded-Proto',
                                           self.request.scheme)
+        print_url = self.request.registry.settings['print_url']
         api_url = self.request.registry.settings['api_url']
         headers = dict(self.request.headers)
         headers.pop("Host", headers)
+        # see https://github.com/mapfish/mapfish-print/blob/95a2f5b7bd9cf0e00779ae366ff4a71f4d7eea1b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java#L922
+        
+        
         unique_filename = datetime.datetime.now().strftime("%y%m%d%H%M%S") + str(random.randint(1000, 9999))
+        
+        #unique_filename = str(uuid.uuid1()) + '@' + self.server_id
+        
+        pdf_download_path =  '/download/-multi' + unique_filename + '.pdf.printout'
 
         with open(create_info_file(print_temp_dir, unique_filename), 'w+') as outfile:
-            json.dump({'status': 'ongoing'}, outfile)
-
-        info = (spec, print_temp_dir, scheme, api_url, headers, unique_filename)
+            data = {
+                "done": False,
+                "status": "running",
+                "elapsedTime": 0,
+                "waitingTime": 0,
+                "downloadURL": pdf_download_path
+            }
+            #json.dump({'status': 'ongoing'}, outfile)
+            json.dump(data, outfile)
+        
+            
+      
+        info = (spec, print_temp_dir, scheme, api_url, print_url, headers, unique_filename)
+        
         p = multiprocessing.Process(target=create_and_merge, args=(info,))
         p.start()
-        response = {'idToCheck': unique_filename}
+        #response = {'idToCheck': unique_filename}
+        
+        response = {"ref":unique_filename,
+                    "statusURL":"/print/print/geoadmin3/status/{}.json".format(unique_filename),
+                    "downloadURL":pdf_download_path}
 
         return response

--- a/print3/views/printmulti.py
+++ b/print3/views/printmulti.py
@@ -326,39 +326,53 @@ def create_and_merge(info):
         log.info('[_merge_pdfs] Starting merge')
         merger = PdfFileMerger()
         expected_file_size = 0
-        for pdf in sorted(pdfs, key=lambda x: x[0]):
-
+        # Send PDF as is if only one
+        if len(pdfs) == 1:
+            pdf = pdfs[0]
             ts, localname = pdf
             if localname is not None:
                 try:
-                    path = open(localname, 'rb')
-                    expected_file_size += os.path.getsize(localname)
-                    merger.append(fileobj=path)
-                    info_json['merged'] += 1
-                    write_info()
+                    info_json['done'] = True
+                    info_json['status'] = 'finished'
+                    filename = create_pdf_path(print_temp_dir, unique_filename)
+                    log.info('[_merge_pdfs] Only one PDF, copied to: %s', filename)
+                    os.rename(localname, filename)
                 except:
-                    return None
+                    return False
+        else:
+            for pdf in sorted(pdfs, key=lambda x: x[0]):
 
-        try:
-            info_json['filesize'] = expected_file_size
-            info_json['written'] = 0
-            info_json['done'] = True
-            info_json['status'] = 'finished'
-            write_info()
-            filename = create_pdf_path(print_temp_dir, unique_filename)
-            log.info('[_merge_pdfs] Writing file.')
-            out = open(filename, 'wb')
-            merger.write(out)
-            log.info('[_merge_pdfs] Merged PDF written to: %s', filename)
-            log.debug(json.dumps(info_json, indent=4))
-        except:
-            return False
+                ts, localname = pdf
+                if localname is not None:
+                    try:
+                        path = open(localname, 'rb')
+                        expected_file_size += os.path.getsize(localname)
+                        merger.append(fileobj=path)
+                        info_json['merged'] += 1
+                        write_info()
+                    except:
+                        return None
 
-        finally:
-            out.close()
-            merger.close()
+            try:
+                info_json['filesize'] = expected_file_size
+                info_json['written'] = 0
+                info_json['done'] = True
+                info_json['status'] = 'finished'
+                write_info()
+                filename = create_pdf_path(print_temp_dir, unique_filename)
+                log.info('[_merge_pdfs] Writing file.')
+                out = open(filename, 'wb')
+                merger.write(out)
+                log.info('[_merge_pdfs] Merged PDF written to: %s', filename)
+                log.debug(json.dumps(info_json, indent=4))
+            except:
+                return False
 
-        return True
+            finally:
+                out.close()
+                merger.close()
+
+            return True
 
     jobs = []
     all_timestamps = []

--- a/print3/views/printmulti.py
+++ b/print3/views/printmulti.py
@@ -267,7 +267,7 @@ def worker(job):
         elif err.code == 403:
             log.error("Access to %s denied", url)
         else:
-            log.error("Unkonw error while accessing %s:", url, err.code)
+            log.error("Unkonw error while accessing %s: %s", url, err.code)
 
         return (timestamp, None)
 

--- a/production.ini.in
+++ b/production.ini.in
@@ -21,20 +21,15 @@ pyramid.includes = pyramid_tm
 
 # Mako specific
 
-sphinxhost = ${sphinxhost}
-wmshost = ${wmshost}
-mapproxyhost = ${mapproxyhost}
-geoadminhost = ${geoadminhost}
-webdav_host = ${webdav_host}
 api_url = ${api_url}
-print_url = ${print_url}
+print_proxy_url = ${print_proxy_url}
+print_server_url = ${print_server_url}
 install_directory = ${current_directory}
 host = ${host}
 apache_base_path = ${apache_base_path}
 apache_entry_path = ${apache_entry_path}
 print_temp_dir=${print_temp_dir}
 http_proxy = ${http_proxy}
-geoadmin_file_storage_bucket = ${geoadmin_file_storage_bucket}
 
 
 ###

--- a/tomcat/print-apps/geoadmin3/config.yaml
+++ b/tomcat/print-apps/geoadmin3/config.yaml
@@ -1,10 +1,10 @@
 pdfConfig: !pdfConfig
-  compressed: false
-  author: "Jeff Konnen"
-  subject: "map.geoportail.lu Print"
-  creator: "Mapfish Print"
+  compressed: true
+  author: "geo.admin.ch team"
+  subject: "map.geo.admin.ch Print"
+  creator: "Mapfish Print V3"
 
-throwErrorOnExtraParameters: true
+throwErrorOnExtraParameters: false
 
 templates:
 


### PR DESCRIPTION
The goal is to isolate totaly https://github.com/geoadmin/mf-geoadmin3's print service from https://github.com/geoadmin/mf-chsdi3  

Everything but the **servlet .war** and the print **proxy view** was basically removed

The print configuration, in `tomcat`is now using MapFish Print v3.

Test it against map.geo.admin.ch's PR https://github.com/geoadmin/mf-geoadmin3/pull/3252

Three base paths are defined:

```
/printserver     Tomcat application (proxy)
/print           Print proxy (pyramid WSGI), dealing with _timstamps_, _zeitreihen_, and so on
/download        Apache direct download
```
