### PR TITLE
Use technical address for print

### DIFF
--- a/rc_prod
+++ b/rc_prod
@@ -1,6 +1,6 @@
 export APACHE_BASE_PATH=main
 export API_URL=//api3.geo.admin.ch
-export PRINT_PROXY_URL=//print.geo.admin.ch
+export PRINT_PROXY_URL=//service-print.prod.bgdi.ch
 export DEPLOY_TARGET=prod
 export MODWSGI_CONFIG=production.ini
 export PRINT_WAR=main


### PR DESCRIPTION
httplib2 doesn't redirect automatically resources for POST requests.

```
ltgal@ip-10-220-4-46 (vpc/mf0 - test):~/service-print **(gal_technical)** $ curl -I http://print.geo.admin.ch
HTTP/1.1 301 Moved Permanently
Content-Length: 0
Date: Wed, 17 Aug 2016 12:26:56 GMT
Location: https://print.geo.admin.ch/
Server: Varnish
X-Varnish: 642145457
Connection: keep-alive
```

VS

```
ltgal@ip-10-220-4-46 (vpc/mf0 - test):~/service-print **(gal_technical)** $ curl -I https://print.geo.admin.ch
HTTP/1.1 200 OK
Access-Control-Allow-Headers: x-requested-with, Content-Type, origin, authorization, accept, client-security-token
Access-Control-Allow-Methods: POST, GET, OPTIONS
Access-Control-Allow-Origin: *
Age: 0
Content-Type: text/html; charset=UTF-8
Date: Wed, 17 Aug 2016 12:27:07 GMT
Last-Modified: Wed, 17 Aug 2016 11:35:36 GMT
Server: Apache/2.2.22 (Debian)
Vary: Accept-Encoding
Via: 1.1 varnish-v4
X-Cache: MISS
X-UA-Compatible: IE=Edge
X-Varnish: 130945248
Connection: keep-alive
```

So for now we'll use the technical addresses and later use a library that can redirect POST as well.
