### PR TITLE
Latest commits in mapfish-print are breaking labels

### DIFF
--- a/0001-do-not-recycle-connection.patch
+++ b/0001-do-not-recycle-connection.patch
@@ -1,0 +1,47 @@
+From 97de606ae4e721ac4dae2a473c4d08a8ef2498fd Mon Sep 17 00:00:00 2001
+From: Marc Monnerat <procrastinatio@gmail.com>
+Date: Fri, 2 Jun 2017 17:29:11 +0200
+Subject: [PATCH 1/1] do not recycle connection
+
+
+Signed-off-by: Marc Monnerat <procrastinatio@gmail.com>
+---
+ src/main/java/org/mapfish/print/PDFUtils.java |    8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/main/java/org/mapfish/print/PDFUtils.java b/src/main/java/org/mapfish/print/PDFUtils.java
+index 62aa290..65fc5f1 100644
+--- a/src/main/java/org/mapfish/print/PDFUtils.java
++++ b/src/main/java/org/mapfish/print/PDFUtils.java
+@@ -70,6 +70,7 @@ import org.mapfish.print.config.layout.TableConfig;
+ import java.util.regex.Pattern;
+ import org.mapfish.print.utils.PJsonObject;
+ import org.w3c.dom.svg.SVGDocument;
++import org.apache.commons.httpclient.HttpClient;
+ 
+ /**
+  * Some utility functions for iText.
+@@ -186,6 +187,7 @@ public class PDFUtils {
+             throws
+             IOException, DocumentException {
+         File uriAsFile = null;
++        HttpClient client = new HttpClient();
+         try {
+             uriAsFile = new File(uri.toString());
+         } catch (Throwable t) {
+@@ -264,7 +266,11 @@ public class PDFUtils {
+                             getMethod.setRequestHeader(entry.getKey(), entry.getValue());
+                         }
+                         if (LOGGER.isDebugEnabled()) LOGGER.debug("loading image: " + uri);
+-                        context.getConfig().getHttpClient(uri).executeMethod(getMethod);
++                        //HttpClient client = new HttpClient();
++                        client.executeMethod(getMethod);
++                        // context.getConfig().getHttpClient(uri).executeMethod(getMethod);
++                         
++                        
+                         statusCode = getMethod.getStatusCode();
+                         statusText = getMethod.getStatusText();
+ 
+-- 
+1.7.10.4
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ service-print
 Print service for [https://map.geo.admin.ch], based on [MapFish Print v3](http://mapfish.github.io/)
 
 
+# Print war
+
+The war file `print-servlet-2.1.3-SNAPSHOT.war` is base on the mapfish-print 2.1.3 branch [#46d901520](https://github.com/mapfish/mapfish-print/commit/46d9015209fb2d975cee3f580bf387cd2f15b2e0)
+with the patch `0001-do-not-recycle-connection.patch? applied.
+
 # Getting started
 
 Checkout the source code:


### PR DESCRIPTION
Hopefully fixes https://github.com/geoadmin/service-print/issues/33

Problem:
https://s.geo.admin.ch/7394d8347c

Only [tomcat](http://service-print.dev.bgdi.ch/mom_labels/)

map.geo.admin.ch with this fix:
https://s.geo.admin.ch/7394db0c76

older version (without source patches)
https://s.geo.admin.ch/7394dc618a

try: Ziegelbrücke (GL)

