### PR TITLE
Disabling cache on printprogress

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -45,6 +45,16 @@ RewriteRule ^${apache_entry_path}/robots.txt ${apache_entry_path}/static/${robot
     Header set Content-type "text/plain"
 </LocationMatch>
 
+<LocationMatch ^${apache_entry_path}/(printprogress|printcancel)>
+  FileETag None
+  <IfModule mod_headers.c>
+    Header unset ETag
+    Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires "Wed, 12 Jan 1980 05:00:00 GMT"
+  </IfModule>
+</LocationMatch>
+
 # define a process group
 # WSGIDaemonProcess, default are 1 process and 15 threads
 WSGIDaemonProcess service-print:${apache_base_path} display-name=%{GROUP} user=${modwsgi_user} threads=${wsgi_threads}


### PR DESCRIPTION
Test on IE9 (https://github.com/geoadmin/service-print/issues/42)

[test link](https://map.geo.admin.ch/?print_url=%2F%2Fservice-print.dev.bgdi.ch)