### PR TITLE
Cleanup up nginx config

### DIFF
--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -12,9 +12,8 @@ events {
 }
 
 http {
-  default_type text/plain;
   # if we use analytics we may want to turn that off
-   access_log /dev/stdout;
+  access_log /dev/stdout;
   sendfile off;
   # this removes the "host_header" related issue
   underscores_in_headers on;
@@ -44,29 +43,39 @@ http {
     root /var/local/print;
 
     location ~ /[0-9]+/print/ {
-      #rewrite ^/[0-9]+/print/(.*) /service-print-main/pdf/$1 break;
       rewrite ^/[0-9]+/print/(.*) /print/$1;
-      #alias /print/;
-      # Do not cache anything
-      #expires off;
-      
-      #proxy_pass http://localhost:${TOMCAT_PORT};
     }
 
-    location ~  /mapfish-print-multi[0-9]+\.pdf\.printout$ {
-        expires off;
-        add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf";
-        #try_files $uri $uri/ =404;
-
-    }
     # PDF download
-    location ~  [0-9]+\.pdf\.printoutXXXX$ {
+    location ~  /mapfish-print-multi[0-9]+\.pdf\.printout$ {
+        types {
+          application/pdf        printout;
+        }
+        expires off;
+
+        add_header Content-Type application/pdf always;
+        add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf" always;
+        break;
+    }
+
+    location ~  ^/mapfish-print[0-9]+\.pdf\.printout$ {
+
+      types {
+          application/pdf        printout;
+      }
+      # Do not cache anything
+      expires off;
+
+      add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf" always;
+    }
+
+    location ~  ^/print/[0-9]+\.pdf\.printout$ {
       # Do not cache anything
       expires off;
       
       rewrite ^/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ /mapfish-print$2$3;
-      add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf";
     }
+
 
     location  /print/ {
       add_header 'Access-Control-Allow-Origin' '*' always;

--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -25,7 +25,7 @@ http {
   # 
   # POST /print/create.json                                                      POST /service-print-main/pdf/create.json
   # 
- # POST /printmulti/create.json             POST /printmulti/create.json
+  # POST /printmulti/create.json             POST /printmulti/create.json
   # 
   # GET  /printprogress?id=232323            GET /printprogress?id=232323
   # 
@@ -51,9 +51,8 @@ http {
         types {
           application/pdf        printout;
         }
-        expires off;
-
-        add_header Content-Type application/pdf always;
+        expires 1h;
+        add_header Cache-Control "public";
         add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf" always;
         break;
     }
@@ -63,15 +62,13 @@ http {
       types {
           application/pdf        printout;
       }
-      # Do not cache anything
-      expires off;
-
+      expires 1h;
+      add_header Cache-Control "public";
       add_header Content-Disposition "attachment; filename=map.geo.admin.ch.pdf" always;
+      break;
     }
 
     location ~  ^/print/[0-9]+\.pdf\.printout$ {
-      # Do not cache anything
-      expires off;
       
       rewrite ^/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ /mapfish-print$2$3;
     }


### PR DESCRIPTION

Fixes https://github.com/geoadmin/service-print/issues/58


```
 # curl -I https://service-print.dev.bgdi.ch/print/781197437449836389.pdf.printout
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 0
Content-Disposition: attachment; filename=map.geo.admin.ch.pdf
Content-Length: 3946246
Content-Type: application/pdf
Date: Fri, 24 Nov 2017 18:02:49 GMT
ETag: "5a185eba-3c3706"
Last-Modified: Fri, 24 Nov 2017 18:02:34 GMT
Server: nginx/1.13.3
Via: 1.1 varnish-v4
X-Cache: MISS
X-Varnish: 18577830
Connection: keep-alive
```

Ignore build errors, jenkins it is not correctly configured