### PR TITLE
Higher limit for POST body size

### DIFF
--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -15,8 +15,15 @@ http {
   # if we use analytics we may want to turn that off
   access_log /dev/stdout;
   sendfile off;
+
   # this removes the "host_header" related issue
   underscores_in_headers on;
+
+  # Max request size. Vector layer may be quite large.
+  # Default is 1M. Empirical value, 50M is enough to print 100'000 points/coordinates
+  # Was unlimited on Apache
+  
+  client_max_body_size 50M;
 
 
   # Apache/Nginx                                   WSGI                            Tomcat


### PR DESCRIPTION
Increase max body size for large vector print. Was unlimited on Apache and `1M` by default on nginx.