### PR TITLE
Modifications for k8s as runtime env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BASEWAR ?= print-servlet-2.1.3-SNAPSHOT.war
 PRINT_SERVER_HOST ?= service-print.dev.bgdi.ch
 TOMCAT_SERVER_URL ?= //service-print.dev.bgdi.ch
 TOMCAT_BASE_URL ?= ajp://localhost:8009
+REFERER ?= https://print.geo.admin.ch
 PRINT_INPUT :=  checker *.html *.yaml *.png WEB-INF
 #PRINT_OUTPUT_BASE := /srv/tomcat/tomcat1/webapps/service-print-$(APACHE_BASE_PATH)
 #PRINT_OUTPUT := $(PRINT_OUTPUT_BASE).war

--- a/dev.env
+++ b/dev.env
@@ -10,3 +10,4 @@ PRINT_SERVER_HOST=service-print.dev.bgdi.ch
 PRINT_TEMP_DIR=/var/local/print
 PRINT_LOGLEVEL=10
 DEBUG=True
+REFERER=https://service-print.bgdi.swisstopo.cloud

--- a/dev.env
+++ b/dev.env
@@ -10,4 +10,4 @@ PRINT_SERVER_HOST=service-print.dev.bgdi.ch
 PRINT_TEMP_DIR=/var/local/print
 PRINT_LOGLEVEL=10
 DEBUG=True
-REFERER=https://service-print.bgdi.swisstopo.cloud
+REFERER=https://service-print.dev.bgdi.ch

--- a/int.env
+++ b/int.env
@@ -10,3 +10,4 @@ PRINT_SERVER_HOST=service-print.int.bgdi.ch
 PRINT_TEMP_DIR=/var/local/print
 PRINT_LOGLEVEL=30
 DEBUG=True
+REFERER=https://service-print.bgdi.swisstopo.cloud

--- a/int.env
+++ b/int.env
@@ -10,4 +10,4 @@ PRINT_SERVER_HOST=service-print.int.bgdi.ch
 PRINT_TEMP_DIR=/var/local/print
 PRINT_LOGLEVEL=30
 DEBUG=True
-REFERER=https://service-print.bgdi.swisstopo.cloud
+REFERER=https://service-print.int.bgdi.ch

--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -91,6 +91,9 @@ http {
       add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
       add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
 
+      # Send a referer
+      proxy_set_header Referer "${REFERER}";
+
       # Do not cache anything
       expires off;
 

--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -1,9 +1,13 @@
-user nginx;
-
 # should be equal to the number of process on the host machine
 worker_processes 8;
 
-error_log /dev/stdout debug;
+# unprivileged container needs slightly different confs,
+# (see https://github.com/nginxinc/docker-nginx-unprivileged for details)
+# - pid file needs to be in /tmp
+# - error.log goes to /var/log/nginx/error.log (which in turn is a symlink to stderr)
+error_log  /var/log/nginx/error.log debug;
+pid        /tmp/nginx.pid;
+
 
 
 events {
@@ -12,8 +16,9 @@ events {
 }
 
 http {
-  # if we use analytics we may want to turn that off
-  access_log /dev/stdout;
+  # see above: this is symlinked in the container to stdout
+  access_log /var/log/nginx/access.log;
+
   sendfile off;
 
   # this removes the "host_header" related issue


### PR DESCRIPTION

*nginx*
modifications to the nginx config to make it usable in a default, unprivileged nginx container, test with
`docker run -it --rm -v ${PWD}/nginx.conf:/etc/nginx/nginx.conf -p 8090:8080 nginxinc/nginx-unprivileged:1.18`